### PR TITLE
fix(nix): specify `lib.types` for `submoduleWith`

### DIFF
--- a/console/program-variables.nix
+++ b/console/program-variables.nix
@@ -21,7 +21,7 @@ let
     { config, ... }:
     let
       cfg = config.home.${optionName};
-      moduleType = lib.submoduleWith {
+      moduleType = lib.types.submoduleWith {
         modules = [{
           options = {
             package = lib.mkOption {


### PR DESCRIPTION
this pr fixes `attribute 'submoduleWith' missing` error when using `program-variables` with attrsets, due to incorrect `lib` scope of `submoduleWith`
